### PR TITLE
Update IdentityModel from 1.12 to 2.8

### DIFF
--- a/Okta.Samples.OAuth.CodeFlow/App_Start/Startup.Auth.cs
+++ b/Okta.Samples.OAuth.CodeFlow/App_Start/Startup.Auth.cs
@@ -79,14 +79,14 @@ namespace Okta.Samples.OAuth.CodeFlow
                         }
 
                         // use the access token to retrieve claims from userinfo
-                        var userInfoClient = new UserInfoClient(new Uri(oidcAuthority + Constants.UserInfoEndpoint), tokenResponse.AccessToken);
+                        var userInfoClient = new UserInfoClient(oidcAuthority + Constants.UserInfoEndpoint);
 
-                        var userInfoResponse = await userInfoClient.GetAsync();
+                        var userInfoResponse = await userInfoClient.GetAsync(tokenResponse.AccessToken);
 
                         //// create new identity
                         var id = new ClaimsIdentity(n.AuthenticationTicket.Identity.AuthenticationType);
                         //adding the claims we get from the userinfo endpoint
-                        id.AddClaims(userInfoResponse.GetClaimsIdentity().Claims);
+                        id.AddClaims(userInfoResponse.Claims);
 
                         //also adding the ID, Access and Refresh tokens to the user claims 
                         id.AddClaim(new Claim("id_token", n.ProtocolMessage.IdToken));

--- a/Okta.Samples.OAuth.CodeFlow/Controllers/CallbackController.cs
+++ b/Okta.Samples.OAuth.CodeFlow/Controllers/CallbackController.cs
@@ -158,12 +158,12 @@ namespace Okta.Samples.OAuth.CodeFlow.Controllers
         {
             string oktaTenantUrl = ConfigurationManager.AppSettings["okta:OAuthAuthority"];
 
-            var userInfoClient = new UserInfoClient(new Uri(oktaTenantUrl + Constants.UserInfoEndpoint), accessToken);
+            var userInfoClient = new UserInfoClient(oktaTenantUrl + Constants.UserInfoEndpoint);
 
-            var userInfo = await userInfoClient.GetAsync();
+            var userInfo = await userInfoClient.GetAsync(accessToken);
 
             var claims = new List<Claim>();
-            userInfo.Claims.ToList().ForEach(ui => claims.Add(new Claim(ui.Item1, ui.Item2)));
+            userInfo.Claims.ToList().ForEach(ui => claims.Add(new Claim(ui.Type, ui.Value)));
 
             return claims;
         }

--- a/Okta.Samples.OAuth.CodeFlow/Okta.Samples.OAuth.CodeFlow.csproj
+++ b/Okta.Samples.OAuth.CodeFlow/Okta.Samples.OAuth.CodeFlow.csproj
@@ -48,9 +48,8 @@
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="IdentityModel, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IdentityModel.1.12.0\lib\net45\IdentityModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="IdentityModel, Version=2.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityModel.2.8.0\lib\net452\IdentityModel.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
@@ -101,7 +100,25 @@
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.2.206221351\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.1\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -120,8 +137,6 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>

--- a/Okta.Samples.OAuth.CodeFlow/Web.config
+++ b/Okta.Samples.OAuth.CodeFlow/Web.config
@@ -60,6 +60,10 @@
         <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>

--- a/Okta.Samples.OAuth.CodeFlow/packages.config
+++ b/Okta.Samples.OAuth.CodeFlow/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net461" />
   <package id="bootstrap" version="3.3.7" targetFramework="net461" />
-  <package id="IdentityModel" version="1.12.0" targetFramework="net461" />
+  <package id="IdentityModel" version="2.8.0" targetFramework="net461" />
   <package id="jQuery" version="3.1.0" targetFramework="net461" />
   <package id="jQuery.Validation" version="1.15.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
@@ -25,5 +25,11 @@
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="Respond" version="1.4.2" targetFramework="net461" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.1" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
   <package id="WebGrease" version="1.6.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
While testing out this project I found that one of the NuGet dependencies was a major version behind.  I bumped it and checked out the source of the new IdentityModel to see what's different.  After making some small edits, it seems to all work correctly.  I am still quite new to Okta/OIDC so any help or review is appreciated.