### PR TITLE
:seedling: Removes hard-coded paths for token and id endpoints

### DIFF
--- a/OktaAspNetExample/Startup.cs
+++ b/OktaAspNetExample/Startup.cs
@@ -53,8 +53,10 @@ namespace OktaAspNetExample
                 {
                     AuthorizationCodeReceived = async n => 
                     {
+                        OpenIdConnectConfiguration config = await n.Options.ConfigurationManager.GetConfigurationAsync(n.Request.CallCancelled).ConfigureAwait(false);
+
                         // Exchange code for access and ID tokens
-                        var tokenClient = new TokenClient(authority + "/v1/token", clientId, clientSecret);
+                        var tokenClient = new TokenClient(config.TokenEndpoint, clientId, clientSecret);
                         var tokenResponse = await tokenClient.RequestAuthorizationCodeAsync(n.Code, redirectUri);
 
                         if (tokenResponse.IsError)
@@ -62,7 +64,7 @@ namespace OktaAspNetExample
                             throw new Exception(tokenResponse.Error);
                         }
 
-                        var userInfoClient = new UserInfoClient(authority + "/v1/userinfo");
+                        var userInfoClient = new UserInfoClient(config.UserInfoEndpoint);
                         var userInfoResponse = await userInfoClient.GetAsync(tokenResponse.AccessToken);
                         var claims = new List<Claim>();
                         claims.AddRange(userInfoResponse.Claims);


### PR DESCRIPTION
This is a non-breaking change, that allows one to specify either the built-in authorization server (https://tenant.okta.com/), or an API authorization server (https://tenant.okta.com/oauth2/default) as the okta:OrgUri parameter. The OWIN middleware has already obtained the metadata from the server by the time we get to the AuthorizationCodeReceived callback, so we can use the endpoint information directly, rather than hardcoded paths. 

Just a lighter-weight way of solving #15 #16 for your consideration