### PR TITLE
:seedling: Adds basic support for AuthN error handling

### DIFF
--- a/OktaAspNetExample/Controllers/HomeController.cs
+++ b/OktaAspNetExample/Controllers/HomeController.cs
@@ -26,5 +26,12 @@ namespace OktaAspNetExample.Controllers
 
             return View();
         }
+
+        public ActionResult AuthNError()
+        {
+            ViewBag.Message = "An authentication error occurred";
+            
+            return View();
+        }
     }
 }

--- a/OktaAspNetExample/OktaAspNetExample.csproj
+++ b/OktaAspNetExample/OktaAspNetExample.csproj
@@ -226,6 +226,7 @@
     <Content Include="Views\Home\Contact.cshtml" />
     <Content Include="Views\Home\Index.cshtml" />
     <Content Include="Views\Account\Claims.cshtml" />
+    <Content Include="Views\Home\AuthNError.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/OktaAspNetExample/Startup.cs
+++ b/OktaAspNetExample/Startup.cs
@@ -10,6 +10,7 @@ using System.Security.Claims;
 using IdentityModel.Client;
 using System;
 using System.Collections.Generic;
+using System.Web;
 using Microsoft.IdentityModel.Tokens;
 
 [assembly: OwinStartup(typeof(OktaAspNetExample.Startup))]
@@ -94,6 +95,14 @@ namespace OktaAspNetExample
                         }
 
                         return Task.CompletedTask;
+                    },
+
+                    AuthenticationFailed = n =>
+                    {
+                        n.HandleResponse();
+                        n.Response.Redirect($"/Home/AuthNError?message={HttpUtility.UrlEncode(n.Exception?.Message ?? "Unknown error")}");
+
+                        return Task.FromResult(0);
                     }
                 },
             });

--- a/OktaAspNetExample/Views/Home/AuthNError.cshtml
+++ b/OktaAspNetExample/Views/Home/AuthNError.cshtml
@@ -1,0 +1,7 @@
+﻿@{
+    ViewBag.Title = "Error";
+}
+<h2>@ViewBag.Title.</h2>
+<h3>@ViewBag.Message</h3>
+
+<p>@Request.Params["message"]</p>


### PR DESCRIPTION
This sample was very valuable to me, being new to both Okta and OIDC, but it did take me a lot longer than I thought to get things up and running. One of the main problems I had was ending up at the dreaded /authorization-code/callback 404 page when something went wrong with the authentication. It had me totally stumped (also being new to OWIN and its behind-the-scenes middleware magic). There are lots of very simple reasons you can end up at this page (user not being assigned, wrong token types), and being dropped at a 404 page didn't help me understand what I had done wrong.

This PR has a very basic hook to the AuthenticationFailed callback, and sends the user off to a basic error page. This allows two things
- To prevent someone new to Okta/OIDC/OWIN getting 'stuck' at a non-existent callback path through misconfiguring their app on the Okta side. They should at least be able to see the failure reason.
- To demonstrate how to hook into the AuthenticationFailed flows to do your own management of the various scenarios (such as the user not having access to the app).